### PR TITLE
Replace Generator[None, None, None] with Iterator[None]

### DIFF
--- a/src/pytest_reverse/__init__.py
+++ b/src/pytest_reverse/__init__.py
@@ -19,9 +19,7 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
-def pytest_collection_modifyitems(
-    config: Config, items: list[Item]
-) -> Iterator[None]:
+def pytest_collection_modifyitems(config: Config, items: list[Item]) -> Iterator[None]:
     if config.getoption("reverse"):
         items[:] = items[::-1]
 

--- a/src/pytest_reverse/__init__.py
+++ b/src/pytest_reverse/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generator
+from typing import Iterator
 
 import pytest
 from _pytest.config import Config
@@ -21,7 +21,7 @@ def pytest_addoption(parser: Parser) -> None:
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_collection_modifyitems(
     config: Config, items: list[Item]
-) -> Generator[None, None, None]:
+) -> Iterator[None]:
     if config.getoption("reverse"):
         items[:] = items[::-1]
 


### PR DESCRIPTION
👋🏽 Hi,  
Thanks for the package, it's small and useful. 

This change replaces `Generator[None, None, None` with `Iterator[None]`. Since the generator doesn't return, send, or accept anything, it can be replaced with the more succinct generic superclass `Iterator`. 

```python
>>> issubclass(typing.Generator, typing.Iterator)
True
```