### PR TITLE
Upgrade pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ entry-points.pytest11.reverse = "pytest_reverse"
 
 [dependency-groups]
 test = [
-  "pytest",
+  "pytest>=9",
 ]
 
 [tool.ruff]
@@ -98,11 +98,7 @@ warn_unreachable = true
 overrides = [ { module = "tests.*", allow_untyped_defs = true } ]
 
 [tool.pytest]
-ini_options.addopts = """\
-    --strict-config
-    --strict-markers
-    """
-ini_options.xfail_strict = true
+strict = true
 
 [tool.rstcheck]
 report_level = "ERROR"

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ test = [
 requires-dist = [{ name = "pytest" }]
 
 [package.metadata.requires-dev]
-test = [{ name = "pytest" }]
+test = [{ name = "pytest", specifier = ">=9" }]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
Use the new proper TOML support [added in pytest 9](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05).
